### PR TITLE
feat: implement draw algorithm and secret friend revelation

### DIFF
--- a/apps/web/src/app/core/models/group.model.ts
+++ b/apps/web/src/app/core/models/group.model.ts
@@ -8,6 +8,7 @@ export interface Group {
   created_by: string;
   created_at: string;
   has_been_drawn: boolean;
+  drawn_at?: string;
   participants_count: number;
   expand?: {
     created_by?: User;

--- a/apps/web/src/app/core/services/draw.service.spec.ts
+++ b/apps/web/src/app/core/services/draw.service.spec.ts
@@ -1,0 +1,155 @@
+import { TestBed } from '@angular/core/testing';
+import { DrawService } from './draw.service';
+import { PocketBaseClient } from '../../infrastructure/pocketbase/pocketbase.client';
+import { GroupService } from './group.service';
+import SessionAuthStore from '../../infrastructure/pocketbase/session.auth.store';
+import InMemoryAuthStore from '../../infrastructure/pocketbase/inMemory.auth.store';
+
+describe('DrawService', () => {
+  let service: DrawService;
+  let mockParticipantCollection: jasmine.SpyObj<ReturnType<PocketBaseClient['instance']['collection']>>;
+  let mockGroupCollection: jasmine.SpyObj<ReturnType<PocketBaseClient['instance']['collection']>>;
+
+  function createMockPbClient() {
+    mockParticipantCollection = jasmine.createSpyObj('ParticipantRecordService', [
+      'getFullList',
+      'update',
+    ]);
+
+    mockGroupCollection = jasmine.createSpyObj('GroupRecordService', [
+      'update',
+    ]);
+
+    const mockPb = {
+      collection: jasmine.createSpy('collection').and.callFake((name: string) => {
+        if (name === 'group_participants') return mockParticipantCollection;
+        if (name === 'groups') return mockGroupCollection;
+        return null;
+      }),
+    };
+
+    return { instance: mockPb } as unknown as jasmine.SpyObj<PocketBaseClient>;
+  }
+
+  function makeParticipant(id: string, giverId: string, giverName: string) {
+    return { id, giver_id: giverId, giver_name: giverName, group_id: 'group-1' };
+  }
+
+  beforeEach(() => {
+    const mockPbClient = createMockPbClient();
+    const mockGroupService = jasmine.createSpyObj('GroupService', ['getById']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        DrawService,
+        { provide: PocketBaseClient, useValue: mockPbClient },
+        { provide: GroupService, useValue: mockGroupService },
+        { provide: SessionAuthStore, useValue: new InMemoryAuthStore() },
+      ],
+    });
+
+    service = TestBed.inject(DrawService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('performDraw', () => {
+    it('should throw when there are fewer than 3 participants', async () => {
+      mockParticipantCollection.getFullList.and.resolveTo([
+        makeParticipant('p1', 'user-1', 'Ana'),
+        makeParticipant('p2', 'user-2', 'Beto'),
+      ]);
+
+      await expectAsync(service.performDraw('group-1')).toBeRejectedWithError(
+        'É necessário no mínimo 3 participantes para realizar o sorteio.'
+      );
+
+      expect(mockParticipantCollection.update).not.toHaveBeenCalled();
+      expect(mockGroupCollection.update).not.toHaveBeenCalled();
+    });
+
+    it('should update all participants with receiver and mark group as drawn', async () => {
+      const participants = [
+        makeParticipant('p1', 'user-1', 'Ana'),
+        makeParticipant('p2', 'user-2', 'Beto'),
+        makeParticipant('p3', 'user-3', 'Caio'),
+      ];
+      mockParticipantCollection.getFullList.and.resolveTo(participants);
+      mockParticipantCollection.update.and.callFake((id: string, data: any) => Promise.resolve({ id, ...data }));
+      mockGroupCollection.update.and.resolveTo({ id: 'group-1', has_been_drawn: true });
+
+      await service.performDraw('group-1');
+
+      expect(mockParticipantCollection.getFullList).toHaveBeenCalledWith(
+        jasmine.objectContaining({ filter: 'group_id = "group-1"' } as any)
+      );
+
+      expect(mockParticipantCollection.update).toHaveBeenCalledTimes(3);
+      expect(mockGroupCollection.update).toHaveBeenCalledWith('group-1', {
+        has_been_drawn: true,
+        drawn_at: jasmine.any(String),
+      });
+    });
+
+    it('should not assign any participant to give a gift to themselves', async () => {
+      const participants = [
+        makeParticipant('p1', 'user-1', 'Ana'),
+        makeParticipant('p2', 'user-2', 'Beto'),
+        makeParticipant('p3', 'user-3', 'Caio'),
+      ];
+      mockParticipantCollection.getFullList.and.resolveTo(participants);
+      mockParticipantCollection.update.and.callFake((id: string, data: any) => Promise.resolve({ id, ...data }));
+      mockGroupCollection.update.and.resolveTo({ id: 'group-1', has_been_drawn: true });
+
+      await service.performDraw('group-1');
+
+      const updates = mockParticipantCollection.update.calls.allArgs();
+      for (const [id, data] of updates) {
+        const participant = participants.find(p => p.id === id)!;
+        expect((data as any).receiver_id).not.toBe(participant.giver_id);
+      }
+    });
+
+    it('should form a complete cycle of giver-receiver pairs', async () => {
+      const participants = [
+        makeParticipant('p1', 'user-1', 'Ana'),
+        makeParticipant('p2', 'user-2', 'Beto'),
+        makeParticipant('p3', 'user-3', 'Caio'),
+      ];
+      mockParticipantCollection.getFullList.and.resolveTo(participants);
+      mockParticipantCollection.update.and.callFake((id: string, data: any) => Promise.resolve({ id, ...data }));
+      mockGroupCollection.update.and.resolveTo({ id: 'group-1', has_been_drawn: true });
+
+      await service.performDraw('group-1');
+
+      const updates = mockParticipantCollection.update.calls.allArgs();
+      const assignedReceivers = updates.map(([_, data]) => (data as any).receiver_id);
+      const allUserIds = participants.map(p => p.giver_id);
+
+      expect(assignedReceivers.sort()).toEqual(allUserIds.sort());
+    });
+  });
+
+  describe('fisherYatesShuffle (private)', () => {
+    it('should not mutate the original array', () => {
+      const original = [1, 2, 3, 4, 5];
+      const copy = [...original];
+      const shuffled = (service as any).fisherYatesShuffle(original);
+      expect(original).toEqual(copy);
+      expect(shuffled).not.toEqual(original);
+      expect(shuffled.sort()).toEqual(original.sort());
+    });
+
+    it('should ensure no element stays in its original position (self-gift prevention)', () => {
+      for (let run = 0; run < 50; run++) {
+        const input = ['a', 'b', 'c', 'd', 'e'];
+        const result = (service as any).fisherYatesShuffle(input);
+        for (let i = 0; i < input.length; i++) {
+          expect(result[i]).not.toBe(input[i]);
+        }
+      }
+    });
+  });
+});

--- a/apps/web/src/app/core/services/draw.service.ts
+++ b/apps/web/src/app/core/services/draw.service.ts
@@ -40,6 +40,7 @@ export class DrawService {
 
     await this.pbClient.instance.collection('groups').update(groupId, {
       has_been_drawn: true,
+      drawn_at: new Date().toISOString(),
     });
   }
 

--- a/apps/web/src/app/core/services/participant.service.spec.ts
+++ b/apps/web/src/app/core/services/participant.service.spec.ts
@@ -85,6 +85,7 @@ describe('ParticipantService', () => {
 
       expect(mockParticipantCollection.getList).toHaveBeenCalledWith(1, 50, {
         filter: 'group_id = "group-1"',
+        sort: '-joined_at',
         expand: 'giver_id,receiver_id',
       });
       expect(result).toEqual(expected as any);

--- a/apps/web/src/app/core/services/participant.service.ts
+++ b/apps/web/src/app/core/services/participant.service.ts
@@ -28,6 +28,7 @@ export class ParticipantService extends BaseCrudService<GroupParticipant> {
     return await this.pbClient.instance.collection('group_participants')
       .getList<GroupParticipant & RecordModel>(1, 50, {
         filter: `group_id = "${groupId}"`,
+        sort: '-joined_at',
         expand: 'giver_id,receiver_id',
       });
   }

--- a/apps/web/src/app/features/admin/admin-dashboard.page.spec.ts
+++ b/apps/web/src/app/features/admin/admin-dashboard.page.spec.ts
@@ -239,6 +239,7 @@ describe('AdminDashboardComponent (responsivo)', () => {
 });
 
 describe('AdminDashboardComponent (erro)', () => {
+  let component: AdminDashboardComponent;
   let fixture: ComponentFixture<AdminDashboardComponent>;
 
   beforeEach(async () => {
@@ -259,6 +260,7 @@ describe('AdminDashboardComponent (erro)', () => {
     });
 
     fixture = TestBed.createComponent(AdminDashboardComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -268,5 +270,15 @@ describe('AdminDashboardComponent (erro)', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('Algo deu errado');
     expect(el.textContent).toContain('TENTAR NOVAMENTE');
+  });
+
+  it('should reload pairs when TENTAR NOVAMENTE is clicked', () => {
+    const loadPairsSpy = spyOn(component, 'loadPairs').and.callThrough();
+    fixture.detectChanges();
+
+    const retryButton = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    retryButton.click();
+
+    expect(loadPairsSpy).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/features/create-group/create-group.page.spec.ts
+++ b/apps/web/src/app/features/create-group/create-group.page.spec.ts
@@ -127,4 +127,24 @@ describe('CreateGroupComponent', () => {
     expect(el.textContent).toContain('Falha de rede');
     expect(component.loading()).toBeFalse();
   });
+
+  it('should show Criando... text during submission', async () => {
+    const groupService = TestBed.inject(GroupService) as jasmine.SpyObj<GroupService>;
+    groupService.create.and.resolveTo({ id: 'new-group-1' } as any);
+
+    component.form.patchValue({ name: 'Meu Grupo' });
+
+    const submitPromise = component.onSubmit();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Criando...');
+    expect(component.loading()).toBeTrue();
+
+    await submitPromise;
+    fixture.detectChanges();
+
+    expect(el.textContent).not.toContain('Criando...');
+    expect(component.loading()).toBeFalse();
+  });
 });

--- a/apps/web/src/app/features/group-dashboard/group-dashboard.page.html
+++ b/apps/web/src/app/features/group-dashboard/group-dashboard.page.html
@@ -84,14 +84,22 @@
           <div class="mt-4 flex flex-wrap gap-2">
             @if (status !== 'SORTEADO') {
               @if (isOrganizerParticipant()) {
-                <button disabled title="Organizador não pode alterar própria participação após a criação do grupo"
-                        class="inline-flex items-center gap-1 px-4 py-2 text-sm font-semibold text-[#5b403d] bg-[#f4f3f2] rounded-xl opacity-50 cursor-not-allowed">
-                  <lucide-icon [img]="LogOutIcon" size="14"></lucide-icon>
-                  DEIXAR DE SER MEMBRO
-                </button>
+                @if ((group()?.participants_count ?? 0) > 1) {
+                  <button (click)="toggleMembership()" [disabled]="isActionLoading()"
+                          class="inline-flex items-center gap-1 px-4 py-2 text-sm font-semibold text-[#5b403d] bg-[#f4f3f2] rounded-xl hover:bg-[#e4e2e0] transition-colors disabled:opacity-50">
+                    <lucide-icon [img]="LogOutIcon" size="14"></lucide-icon>
+                    DEIXAR DE SER MEMBRO
+                  </button>
+                } @else {
+                  <button disabled title="Você é o único participante. Adicione mais pessoas antes de sair."
+                          class="inline-flex items-center gap-1 px-4 py-2 text-sm font-semibold text-[#5b403d] bg-[#f4f3f2] rounded-xl opacity-50 cursor-not-allowed">
+                    <lucide-icon [img]="LogOutIcon" size="14"></lucide-icon>
+                    DEIXAR DE SER MEMBRO
+                  </button>
+                }
               } @else {
-                <button disabled title="Organizador pode se tornar membro apenas durante a criação do grupo"
-                        class="inline-flex items-center gap-1 px-4 py-2 text-sm font-semibold text-secondary bg-secondary/10 rounded-xl opacity-50 cursor-not-allowed">
+                <button (click)="toggleMembership()" [disabled]="isActionLoading()"
+                        class="inline-flex items-center gap-1 px-4 py-2 text-sm font-semibold text-secondary bg-secondary/10 rounded-xl hover:bg-secondary/20 transition-colors disabled:opacity-50">
                   <lucide-icon [img]="UserPlusIcon" size="14"></lucide-icon>
                   TORNAR-SE MEMBRO
                 </button>
@@ -115,7 +123,7 @@
           <button (click)="leaveGroup()" [disabled]="isActionLoading()"
                   class="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-[#ba1a1a] bg-[#ba1a1a]/5 rounded-xl hover:bg-[#ba1a1a]/10 transition-colors disabled:opacity-50">
             <lucide-icon [img]="LogOutIcon" size="14"></lucide-icon>
-            SAIR DO GRUPO
+            DEIXAR DE SER MEMBRO
           </button>
         </div>
       }
@@ -152,9 +160,12 @@
                   </div>
                   <div>
                     <p class="font-semibold text-[#1a1c1c]">{{ p.giver_name || p.giver_id || 'Participante' }}</p>
-                    @if (p.giver_id === group()?.created_by) {
-                      <p class="text-xs text-primary font-medium">Organizador</p>
-                    }
+                    <div class="flex items-center gap-2 text-xs text-[#5b403d]">
+                      @if (p.giver_id === group()?.created_by) {
+                        <span class="text-primary font-medium">Organizador</span>
+                      }
+                      <span>Entrou em {{ p.joined_at | date: 'dd/MM/yyyy' }}</span>
+                    </div>
                   </div>
                 </div>
                 @if (status !== 'SORTEADO' && p.giver_id !== group()?.created_by) {
@@ -179,6 +190,16 @@
   </main>
 
   <app-bottom-nav [items]="navItems"></app-bottom-nav>
+
+  <app-confirm-modal
+    [show]="showConfirmModal()"
+    [title]="confirmModalTitle()"
+    [message]="confirmModalMessage()"
+    [confirmText]="confirmModalConfirmText()"
+    [cancelText]="confirmModalCancelText()"
+    (confirm)="onModalConfirm()"
+    (cancel)="onModalCancel()"
+  />
 
   <div class="fixed top-0 right-0 -z-10 w-1/2 h-1/2 bg-gradient-to-bl from-primary/5 to-transparent blur-3xl opacity-50 pointer-events-none"></div>
 </div>

--- a/apps/web/src/app/features/group-dashboard/group-dashboard.page.html
+++ b/apps/web/src/app/features/group-dashboard/group-dashboard.page.html
@@ -37,8 +37,24 @@
           @if (myParticipant()?.receiver_id) {
             <lucide-icon [img]="GiftIcon" size="48" class="mx-auto mb-4 text-[#a20513]"></lucide-icon>
             <h2 class="text-xl font-bold text-[#1a1c1c] mb-2">Seu amigo secreto é...</h2>
-            <p class="text-3xl font-black text-primary mb-2">{{ myParticipant()?.receiver_name || '—' }}</p>
-            <p class="text-[#5b403d] text-sm">NÃO CONTE PARA NINGUÉM!</p>
+            @if (isRevealed()) {
+              <p class="text-3xl font-black text-primary mb-2">{{ myParticipant()?.receiver_name || '—' }}</p>
+              <p class="text-[#5b403d] text-sm mb-4">NÃO CONTE PARA NINGUÉM!</p>
+              <button (click)="toggleRevelation()"
+                      class="inline-flex items-center gap-1 px-4 py-2 text-sm font-semibold text-[#5b403d] bg-[#f4f3f2] rounded-xl hover:bg-[#e4e2e0] transition-colors">
+                <lucide-icon [img]="EyeOffIcon" size="14"></lucide-icon>
+                OCULTAR
+              </button>
+            } @else {
+              <div class="mb-4">
+                <div class="text-3xl font-black text-primary/20 select-none mb-2 blur-sm">????</div>
+              </div>
+              <button (click)="toggleRevelation()"
+                      class="inline-flex items-center gap-1 px-6 py-3 bg-[#a20513] text-white font-semibold rounded-xl hover:bg-[#93000e] transition-colors">
+                <lucide-icon [img]="EyeIcon" size="18"></lucide-icon>
+                REVELAR
+              </button>
+            }
           } @else {
             <lucide-icon [img]="SparklesIcon" size="48" class="mx-auto mb-4 text-[#e4beba]"></lucide-icon>
             <h2 class="text-xl font-bold text-[#1a1c1c] mb-2">Aguardando sorteio</h2>

--- a/apps/web/src/app/features/group-dashboard/group-dashboard.page.spec.ts
+++ b/apps/web/src/app/features/group-dashboard/group-dashboard.page.spec.ts
@@ -179,6 +179,19 @@ describe('GroupDashboardComponent (integração - sorteado)', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('Seu amigo secreto é');
   });
+
+  it('should hide receiver name by default and reveal on toggle', async () => {
+    await auth.login('caio@exemplo.com', '1234567890');
+    await createComponent();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('????');
+    expect(el.textContent).toContain('REVELAR');
+    component.toggleRevelation();
+    fixture.detectChanges();
+    expect(el.textContent).toContain('ana');
+    expect(el.textContent).toContain('OCULTAR');
+    expect(el.textContent).toContain('NÃO CONTE PARA NINGUÉM!');
+  });
 });
 
 describe('GroupDashboardComponent (exibição)', () => {
@@ -337,7 +350,46 @@ describe('GroupDashboardComponent (exibição)', () => {
     await setup({ isOrganizer: false, hasBeenDrawn: true, currentUserId: 'user-beto' });
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('Seu amigo secreto é');
+    component.toggleRevelation();
+    fixture.detectChanges();
     expect(el.textContent).toContain('Caio');
+  });
+
+  it('should hide receiver name by default', async () => {
+    await setup({ isOrganizer: false, hasBeenDrawn: true, currentUserId: 'user-beto' });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Seu amigo secreto é');
+    expect(el.textContent).not.toContain('Caio');
+    expect(el.textContent).toContain('REVELAR');
+  });
+
+  it('should show receiver name after reveal', async () => {
+    await setup({ isOrganizer: false, hasBeenDrawn: true, currentUserId: 'user-beto' });
+    component.toggleRevelation();
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Caio');
+    expect(el.textContent).toContain('OCULTAR');
+    expect(el.textContent).toContain('NÃO CONTE PARA NINGUÉM!');
+  });
+
+  it('should re-hide receiver name after toggling twice', async () => {
+    await setup({ isOrganizer: false, hasBeenDrawn: true, currentUserId: 'user-beto' });
+    component.toggleRevelation();
+    fixture.detectChanges();
+    component.toggleRevelation();
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).not.toContain('Caio');
+    expect(el.textContent).toContain('REVELAR');
+  });
+
+  it('should hide name for organizer who is also participant when drawn', async () => {
+    await setup({ isOrganizer: true, hasBeenDrawn: true, currentUserId: 'user-ana' });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Seu amigo secreto é');
+    expect(el.textContent).toContain('????');
+    expect(el.textContent).toContain('REVELAR');
   });
 
   it('should show bottom navigation', async () => {

--- a/apps/web/src/app/features/group-dashboard/group-dashboard.page.spec.ts
+++ b/apps/web/src/app/features/group-dashboard/group-dashboard.page.spec.ts
@@ -377,22 +377,22 @@ describe('GroupDashboardComponent (exibição)', () => {
     expect(el.textContent).toContain('COPIAR');
   });
 
-  it('should show SAIR DO GRUPO for participant when not drawn', async () => {
+  it('should show DEIXAR DE SER MEMBRO for participant when not drawn', async () => {
     await setup({ isOrganizer: false, hasBeenDrawn: false, currentUserId: 'user-beto' });
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.textContent).toContain('SAIR DO GRUPO');
+    expect(el.textContent).toContain('DEIXAR DE SER MEMBRO');
   });
 
-  it('should hide SAIR DO GRUPO for organizer', async () => {
+  it('should show DEIXAR DE SER MEMBRO for organizer who is a participant', async () => {
     await setup();
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.textContent).not.toContain('SAIR DO GRUPO');
+    expect(el.textContent).toContain('DEIXAR DE SER MEMBRO');
   });
 
-  it('should hide SAIR DO GRUPO for participant when drawn', async () => {
+  it('should hide DEIXAR DE SER MEMBRO for participant when drawn', async () => {
     await setup({ isOrganizer: false, hasBeenDrawn: true, currentUserId: 'user-beto' });
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.textContent).not.toContain('SAIR DO GRUPO');
+    expect(el.textContent).not.toContain('DEIXAR DE SER MEMBRO');
   });
 
   it('should hide admin area from non-organizer', async () => {
@@ -402,7 +402,6 @@ describe('GroupDashboardComponent (exibição)', () => {
     expect(el.textContent).not.toContain('REALIZAR SORTEIO');
     expect(el.textContent).not.toContain('EXCLUIR GRUPO');
     expect(el.textContent).not.toContain('Ver resultado do sorteio');
-    expect(el.textContent).not.toContain('DEIXAR DE SER MEMBRO');
     expect(el.textContent).not.toContain('TORNAR-SE MEMBRO');
   });
 
@@ -470,6 +469,159 @@ describe('GroupDashboardComponent (exibição)', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('TORNAR-SE MEMBRO');
   });
+
+  it('should call performDraw when organizer confirms', async () => {
+    await setup({ isOrganizer: true, hasBeenDrawn: false, participantCount: 3 });
+    const drawService = TestBed.inject(DrawService) as jasmine.SpyObj<DrawService>;
+
+    const drawPromise = component.performDraw();
+    component.onModalConfirm();
+    await drawPromise;
+
+    expect(drawService.performDraw).toHaveBeenCalledWith('grupo-1');
+  });
+
+  it('should set error when performDraw fails', async () => {
+    await setup({ isOrganizer: true, hasBeenDrawn: false, participantCount: 3 });
+    const drawService = TestBed.inject(DrawService) as jasmine.SpyObj<DrawService>;
+    drawService.performDraw.and.rejectWith(new Error('Falha no sorteio'));
+
+    const drawPromise = component.performDraw();
+    component.onModalConfirm();
+    await drawPromise;
+
+    expect(component.error()).toContain('Falha no sorteio');
+  });
+
+  it('should not call performDraw when cancelled', async () => {
+    await setup({ isOrganizer: true, hasBeenDrawn: false, participantCount: 3 });
+    const drawService = TestBed.inject(DrawService) as jasmine.SpyObj<DrawService>;
+
+    const drawPromise = component.performDraw();
+    component.onModalCancel();
+    await drawPromise;
+
+    expect(drawService.performDraw).not.toHaveBeenCalled();
+  });
+
+  it('should call deleteGroup and navigate on confirm', async () => {
+    await setup({ isOrganizer: true, hasBeenDrawn: false });
+    const router = TestBed.inject(Router);
+    const navigateSpy = spyOn(router, 'navigate');
+    const participantService = TestBed.inject(ParticipantService) as jasmine.SpyObj<ParticipantService>;
+    const groupService = TestBed.inject(GroupService) as jasmine.SpyObj<GroupService>;
+
+    const deletePromise = component.deleteGroup();
+    component.onModalConfirm();
+    await deletePromise;
+
+    expect(participantService.delete).toHaveBeenCalledTimes(3);
+    expect(groupService.delete).toHaveBeenCalledWith('grupo-1');
+    expect(navigateSpy).toHaveBeenCalledWith(['/my-groups']);
+  });
+
+  it('should not delete when deleteGroup is cancelled', async () => {
+    await setup({ isOrganizer: true, hasBeenDrawn: false });
+    const groupService = TestBed.inject(GroupService) as jasmine.SpyObj<GroupService>;
+
+    const deletePromise = component.deleteGroup();
+    component.onModalCancel();
+    await deletePromise;
+
+    expect(groupService.delete).not.toHaveBeenCalled();
+  });
+
+  it('should remove organizer from participants via toggleMembership', async () => {
+    await setup({ isOrganizer: true, hasBeenDrawn: false, participantCount: 3 });
+    const participantService = TestBed.inject(ParticipantService) as jasmine.SpyObj<ParticipantService>;
+
+    const togglePromise = component.toggleMembership();
+    component.onModalConfirm();
+    await togglePromise;
+
+    expect(participantService.delete).toHaveBeenCalledWith('p1');
+  });
+
+  it('should add organizer as participant via toggleMembership', async () => {
+    const uid = 'user-ana';
+    const createdBy = uid;
+
+    const mockGroupService = jasmine.createSpyObj('GroupService', ['getById', 'delete']);
+    mockGroupService.getById.and.resolveTo({
+      id: 'grupo-1', name: 'Amigo Secreto 2024', created_by: createdBy,
+      has_been_drawn: false, participants_count: 1, created_at: new Date().toISOString(),
+    });
+
+    const mockParticipantService = jasmine.createSpyObj('ParticipantService', ['getParticipants', 'delete', 'joinGroup']);
+    mockParticipantService.getParticipants.and.resolveTo({
+      items: [
+        { id: 'p2', giver_id: 'user-beto', giver_name: 'Beto', receiver_id: null, receiver_name: null, group_id: 'grupo-1', joined_at: new Date().toISOString(),
+          expand: { giver_id: { id: 'user-beto', name: 'Beto' } } },
+      ],
+      total: 1,
+    } as any);
+    mockParticipantService.joinGroup.and.resolveTo({} as any);
+    const mockDrawService = jasmine.createSpyObj('DrawService', ['performDraw']);
+    const mockAuthService = jasmine.createSpyObj('AuthService', [], {
+      user: { id: uid, name: 'Ana' },
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [GroupDashboardComponent],
+      providers: [
+        provideRouter(routes),
+        { provide: GroupService, useValue: mockGroupService },
+        { provide: ParticipantService, useValue: mockParticipantService },
+        { provide: DrawService, useValue: mockDrawService },
+        { provide: AuthService, useValue: mockAuthService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GroupDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('groupId', 'grupo-1');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const togglePromise = component.toggleMembership();
+    component.onModalConfirm();
+    await togglePromise;
+
+    expect(mockParticipantService.joinGroup).toHaveBeenCalledWith('grupo-1');
+  });
+
+  it('should copy invite link to clipboard', async () => {
+    await setup();
+    const mockWriteText = jasmine.createSpy('writeText').and.resolveTo();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      configurable: true,
+    });
+
+    await component.copyInviteLink();
+
+    expect(mockWriteText).toHaveBeenCalledWith(component.inviteUrl());
+    expect(component.copied()).toBe(true);
+  });
+
+  it('should reset copied state after timeout', async () => {
+    await setup();
+    const mockWriteText = jasmine.createSpy('writeText').and.resolveTo();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      configurable: true,
+    });
+    jasmine.clock().install();
+
+    await component.copyInviteLink();
+    expect(component.copied()).toBe(true);
+
+    jasmine.clock().tick(2001);
+    expect(component.copied()).toBe(false);
+
+    jasmine.clock().uninstall();
+  });
 });
 
 describe('GroupDashboardComponent (responsivo)', () => {
@@ -529,6 +681,7 @@ describe('GroupDashboardComponent (responsivo)', () => {
 });
 
 describe('GroupDashboardComponent (erro)', () => {
+  let component: GroupDashboardComponent;
   let fixture: ComponentFixture<GroupDashboardComponent>;
 
   beforeEach(async () => {
@@ -559,6 +712,7 @@ describe('GroupDashboardComponent (erro)', () => {
     });
 
     fixture = TestBed.createComponent(GroupDashboardComponent);
+    component = fixture.componentInstance;
     fixture.componentRef.setInput('groupId', 'grupo-1');
     fixture.detectChanges();
     await fixture.whenStable();
@@ -568,6 +722,16 @@ describe('GroupDashboardComponent (erro)', () => {
   it('should show error state and retry button', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('TENTAR NOVAMENTE');
+  });
+
+  it('should reload data when TENTAR NOVAMENTE is clicked', () => {
+    const loadDataSpy = spyOn(component, 'loadData').and.callThrough();
+    fixture.detectChanges();
+
+    const retryButton = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    retryButton.click();
+
+    expect(loadDataSpy).toHaveBeenCalled();
   });
 });
 
@@ -632,10 +796,11 @@ describe('GroupDashboardComponent (integração - sair)', () => {
     const participantsDataBefore: any = await participantsResBefore.json();
     const totalCountBefore = participantsDataBefore.items.length;
 
-    spyOn(window, 'confirm').and.returnValue(true);
     const navigateSpy = spyOn(TestBed.inject(Router), 'navigate');
 
-    await ngZone.run(() => component.leaveGroup());
+    const leavePromise = ngZone.run(() => component.leaveGroup());
+    component.onModalConfirm();
+    await leavePromise;
     fixture.detectChanges();
 
     expect(navigateSpy).toHaveBeenCalledWith(['/my-groups']);
@@ -658,10 +823,11 @@ describe('GroupDashboardComponent (integração - sair)', () => {
 
     const initialCount = component.group()!.participants_count;
 
-    spyOn(window, 'confirm').and.returnValue(true);
     spyOn(TestBed.inject(Router), 'navigate');
 
-    await ngZone.run(() => component.leaveGroup());
+    const leavePromise = ngZone.run(() => component.leaveGroup());
+    component.onModalConfirm();
+    await leavePromise;
     fixture.detectChanges();
 
     const token = await loginToken();
@@ -685,14 +851,14 @@ describe('GroupDashboardComponent (integração - sair)', () => {
     const participantsDataBefore: any = await participantsResBefore.json();
     const totalCountBefore = participantsDataBefore.items.length;
 
-    spyOn(window, 'confirm').and.returnValue(true);
-
     const betoParticipant = participantsDataBefore.items.find(
       (p: any) => p.giver_name === 'beto'
     );
     expect(betoParticipant).toBeTruthy();
 
-    await ngZone.run(() => component.removeParticipant(betoParticipant));
+    const removePromise = ngZone.run(() => component.removeParticipant(betoParticipant));
+    component.onModalConfirm();
+    await removePromise;
     fixture.detectChanges();
 
     const participantsRes = await fetch(
@@ -713,8 +879,6 @@ describe('GroupDashboardComponent (integração - sair)', () => {
 
     const initialCount = component.group()!.participants_count;
 
-    spyOn(window, 'confirm').and.returnValue(true);
-
     const token = await loginToken();
     const participantsResBefore = await fetch(
       `${POCKETBASE_DIRECT_URL}/api/collections/group_participants/records?filter=(group_id='${component.groupId}')&perPage=100`,
@@ -726,7 +890,9 @@ describe('GroupDashboardComponent (integração - sair)', () => {
     );
     expect(betoParticipant).toBeTruthy();
 
-    await ngZone.run(() => component.removeParticipant(betoParticipant));
+    const removePromise = ngZone.run(() => component.removeParticipant(betoParticipant));
+    component.onModalConfirm();
+    await removePromise;
 
     const groupRes = await fetch(
       `${POCKETBASE_DIRECT_URL}/api/collections/groups/records/${component.groupId}`,

--- a/apps/web/src/app/features/group-dashboard/group-dashboard.page.ts
+++ b/apps/web/src/app/features/group-dashboard/group-dashboard.page.ts
@@ -10,7 +10,7 @@ import { DrawService } from '../../core/services/draw.service';
 import type { Group } from '../../core/models/group.model';
 import type { GroupParticipant } from '../../core/models/group-participant.model';
 import type { User } from '../../core/models/user.model';
-import { LucideAngularModule, Gift, Users, ChevronLeft, PlusCircle, User as UserIcon, ShieldCheck, Sparkles, ArrowRight, Copy, LogOut, Trash2, UserPlus } from 'lucide-angular';
+import { LucideAngularModule, Gift, Users, ChevronLeft, PlusCircle, User as UserIcon, ShieldCheck, Sparkles, ArrowRight, Copy, LogOut, Trash2, UserPlus, Eye, EyeOff } from 'lucide-angular';
 
 @Component({
   selector: 'app-group-dashboard',
@@ -35,6 +35,8 @@ export class GroupDashboardComponent implements OnInit {
   readonly LogOutIcon = LogOut;
   readonly Trash2Icon = Trash2;
   readonly UserPlusIcon = UserPlus;
+  readonly EyeIcon = Eye;
+  readonly EyeOffIcon = EyeOff;
 
   readonly navItems: NavItem[] = [
     { label: 'Grupos', icon: Users, route: '/my-groups' },
@@ -57,6 +59,7 @@ export class GroupDashboardComponent implements OnInit {
   confirmModalConfirmText = signal('Confirmar');
   confirmModalCancelText = signal('Cancelar');
   private confirmResolve: ((value: boolean) => void) | null = null;
+  readonly isRevealed = signal(false);
 
   readonly isOrganizer = computed(() => {
     const g = this.group();
@@ -88,6 +91,10 @@ export class GroupDashboardComponent implements OnInit {
     if (g.has_been_drawn) return 'SORTEADO';
     if (g.participants_count >= 3) return 'ATIVO';
     return 'PENDENTE';
+  }
+
+  toggleRevelation() {
+    this.isRevealed.update(v => !v);
   }
 
   ngOnInit() {

--- a/apps/web/src/app/features/group-dashboard/group-dashboard.page.ts
+++ b/apps/web/src/app/features/group-dashboard/group-dashboard.page.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit, inject, signal, computed, Input } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
+import { DatePipe } from '@angular/common';
+import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
 import { BottomNavComponent, NavItem } from '../../shared/components/bottom-nav/bottom-nav.component';
 import { GroupService } from '../../core/services/group.service';
 import { ParticipantService } from '../../core/services/participant.service';
@@ -13,7 +15,7 @@ import { LucideAngularModule, Gift, Users, ChevronLeft, PlusCircle, User as User
 @Component({
   selector: 'app-group-dashboard',
   standalone: true,
-  imports: [RouterLink, LucideAngularModule, BottomNavComponent],
+  imports: [RouterLink, LucideAngularModule, BottomNavComponent, ConfirmModalComponent, DatePipe],
   templateUrl: './group-dashboard.page.html',
 })
 export class GroupDashboardComponent implements OnInit {
@@ -49,6 +51,12 @@ export class GroupDashboardComponent implements OnInit {
   copied = signal(false);
   isDrawLoading = signal(false);
   isActionLoading = signal(false);
+  showConfirmModal = signal(false);
+  confirmModalTitle = signal('');
+  confirmModalMessage = signal('');
+  confirmModalConfirmText = signal('Confirmar');
+  confirmModalCancelText = signal('Cancelar');
+  private confirmResolve: ((value: boolean) => void) | null = null;
 
   readonly isOrganizer = computed(() => {
     const g = this.group();
@@ -104,10 +112,34 @@ export class GroupDashboardComponent implements OnInit {
     }
   }
 
+  private promptConfirm(title: string, message: string, confirmText = 'Confirmar', cancelText = 'Cancelar'): Promise<boolean> {
+    this.confirmModalTitle.set(title);
+    this.confirmModalMessage.set(message);
+    this.confirmModalConfirmText.set(confirmText);
+    this.confirmModalCancelText.set(cancelText);
+    this.showConfirmModal.set(true);
+    return new Promise(resolve => { this.confirmResolve = resolve; });
+  }
+
+  onModalConfirm() {
+    this.confirmResolve?.(true);
+    this.confirmResolve = null;
+    this.showConfirmModal.set(false);
+  }
+
+  onModalCancel() {
+    this.confirmResolve?.(false);
+    this.confirmResolve = null;
+    this.showConfirmModal.set(false);
+  }
+
   async performDraw() {
-    if (!confirm('Tem certeza que deseja realizar o sorteio? Esta ação não pode ser desfeita.')) {
-      return;
-    }
+    const confirmed = await this.promptConfirm(
+      'Realizar sorteio',
+      'Tem certeza que deseja realizar o sorteio? Esta ação não pode ser desfeita.',
+      'Sim, realizar',
+    );
+    if (!confirmed) return;
     this.isDrawLoading.set(true);
     try {
       await this.drawService.performDraw(this.groupId);
@@ -133,9 +165,19 @@ export class GroupDashboardComponent implements OnInit {
     if (this.group()?.has_been_drawn) {
       throw new Error('Não é possível alterar participação após o sorteio.');
     }
+    const g = this.group();
+    const isLeaving = this.isOrganizerParticipant();
+    const confirmed = await this.promptConfirm(
+      isLeaving ? 'Sair do grupo' : 'Entrar no grupo',
+      isLeaving
+        ? `Tem certeza que deseja deixar de ser membro do grupo "${g?.name || ''}"?`
+        : `Deseja entrar como participante do grupo "${g?.name || ''}"?`,
+      isLeaving ? 'Sim, sair' : 'Sim, entrar',
+    );
+    if (!confirmed) return;
     this.isActionLoading.set(true);
     try {
-      if (this.isOrganizerParticipant()) {
+      if (isLeaving) {
         if (this.participants().length <= 1) {
           throw new Error('Você é o único participante. Adicione mais pessoas antes de sair.');
         }
@@ -155,9 +197,12 @@ export class GroupDashboardComponent implements OnInit {
   }
 
   async removeParticipant(participant: GroupParticipant) {
-    if (!confirm('Tem certeza que deseja remover este participante?')) {
-      return;
-    }
+    const confirmed = await this.promptConfirm(
+      'Remover participante',
+      `Tem certeza que deseja remover ${participant.giver_name || 'este participante'} do grupo?`,
+      'Sim, remover',
+    );
+    if (!confirmed) return;
     this.isActionLoading.set(true);
     try {
       await this.participantService.delete(participant.id);
@@ -171,9 +216,12 @@ export class GroupDashboardComponent implements OnInit {
 
   async leaveGroup() {
     const g = this.group();
-    if (!confirm(`Tem certeza que deseja sair do grupo "${g?.name || ''}"?`)) {
-      return;
-    }
+    const confirmed = await this.promptConfirm(
+      'Sair do grupo',
+      `Tem certeza que deseja sair do grupo "${g?.name || ''}"?`,
+      'Sim, sair',
+    );
+    if (!confirmed) return;
     this.isActionLoading.set(true);
     try {
       const myP = this.myParticipant();
@@ -190,9 +238,12 @@ export class GroupDashboardComponent implements OnInit {
   async deleteGroup() {
     const g = this.group();
     if (!g) return;
-    if (!confirm(`Tem certeza que deseja excluir o grupo "${g.name}"? Esta ação não pode ser desfeita.`)) {
-      return;
-    }
+    const confirmed = await this.promptConfirm(
+      'Excluir grupo',
+      `Tem certeza que deseja excluir o grupo "${g.name}"? Esta ação não pode ser desfeita.`,
+      'Sim, excluir',
+    );
+    if (!confirmed) return;
     this.isActionLoading.set(true);
     try {
       const participants = this.participants();

--- a/apps/web/src/app/features/my-groups/my-groups.page.spec.ts
+++ b/apps/web/src/app/features/my-groups/my-groups.page.spec.ts
@@ -177,6 +177,7 @@ describe('MyGroupsComponent (responsivo)', () => {
 });
 
 describe('MyGroupsComponent (erro)', () => {
+  let component: MyGroupsComponent;
   let fixture: ComponentFixture<MyGroupsComponent>;
 
   beforeAll(async () => {
@@ -193,6 +194,7 @@ describe('MyGroupsComponent (erro)', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(MyGroupsComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -208,6 +210,16 @@ describe('MyGroupsComponent (erro)', () => {
     expect(el.textContent).toContain('TENTAR NOVAMENTE');
     expect(el.querySelectorAll('app-group-card').length).toBe(0);
     expect(el.textContent).not.toContain('Nenhum grupo ainda');
+  });
+
+  it('should reload groups when TENTAR NOVAMENTE is clicked', () => {
+    const loadGroupsSpy = spyOn(component, 'loadGroups').and.callThrough();
+    fixture.detectChanges();
+
+    const retryButton = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    retryButton.click();
+
+    expect(loadGroupsSpy).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/shared/components/confirm-modal/confirm-modal.component.ts
+++ b/apps/web/src/app/shared/components/confirm-modal/confirm-modal.component.ts
@@ -1,0 +1,39 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-confirm-modal',
+  standalone: true,
+  template: `
+    @if (show()) {
+      <div class="fixed inset-0 z-50 flex items-center justify-center p-4"
+           (click)="cancel.emit()">
+        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
+        <div class="relative bg-white rounded-2xl shadow-2xl max-w-sm w-full p-6 animate-in fade-in zoom-in-95 duration-200"
+             (click)="$event.stopPropagation()">
+          <h3 class="text-lg font-bold text-[#1a1c1c] mb-2">{{ title() }}</h3>
+          <p class="text-sm text-[#5b403d] mb-6 leading-relaxed">{{ message() }}</p>
+          <div class="flex justify-end gap-3">
+            <button (click)="cancel.emit()"
+                    class="px-4 py-2 text-sm font-semibold text-[#5b403d] bg-[#f4f3f2] rounded-xl hover:bg-[#e4e2e0] transition-colors">
+              {{ cancelText() }}
+            </button>
+            <button (click)="confirm.emit()"
+                    class="px-4 py-2 text-sm font-semibold text-white bg-[#a20513] rounded-xl hover:bg-[#93000e] transition-colors">
+              {{ confirmText() }}
+            </button>
+          </div>
+        </div>
+      </div>
+    }
+  `,
+})
+export class ConfirmModalComponent {
+  readonly show = input(false);
+  readonly title = input('Confirmar');
+  readonly message = input('');
+  readonly confirmText = input('Confirmar');
+  readonly cancelText = input('Cancelar');
+
+  readonly confirm = output<void>();
+  readonly cancel = output<void>();
+}

--- a/db/pb_hooks/seed.pb.js
+++ b/db/pb_hooks/seed.pb.js
@@ -61,11 +61,14 @@ onBootstrap((e) => {
 
         const userNames = testUserEmails.map(e => e.split("@")[0]);
 
+        const now = new Date().toISOString();
+
         for (let i = 0; i < userIds.length; i++) {
             const partRecord = new Record(participantsCollection);
             partRecord.set("group_id", groupRecord.id);
             partRecord.set("giver_id", userIds[i]);
             partRecord.set("giver_name", userNames[i]);
+            partRecord.set("joined_at", now);
             $app.save(partRecord);
         }
 
@@ -74,6 +77,7 @@ onBootstrap((e) => {
         drawnGroupRecord.set("created_by", userIds[0]);
         drawnGroupRecord.set("participants_count", 0);
         drawnGroupRecord.set("has_been_drawn", true);
+        drawnGroupRecord.set("drawn_at", now);
         $app.save(drawnGroupRecord);
 
         const drawnParticipantIds = [];
@@ -82,6 +86,7 @@ onBootstrap((e) => {
             partRecord.set("group_id", drawnGroupRecord.id);
             partRecord.set("giver_id", userIds[i]);
             partRecord.set("giver_name", userNames[i]);
+            partRecord.set("joined_at", now);
             $app.save(partRecord);
             drawnParticipantIds.push({ record: partRecord, userId: userIds[i], name: userNames[i] });
         }
@@ -141,11 +146,14 @@ if (env === "dev") {
 
             const userNames = testUserEmails.map(e => e.split("@")[0]);
 
+            const now = new Date().toISOString();
+
             for (let i = 0; i < userIds.length; i++) {
                 const partRecord = new Record(participantsCollection);
                 partRecord.set("group_id", groupRecord.id);
                 partRecord.set("giver_id", userIds[i]);
                 partRecord.set("giver_name", userNames[i]);
+                partRecord.set("joined_at", now);
                 $app.save(partRecord);
             }
 
@@ -154,6 +162,7 @@ if (env === "dev") {
             drawnGroupRecord.set("created_by", userIds[0]);
             drawnGroupRecord.set("participants_count", 0);
             drawnGroupRecord.set("has_been_drawn", true);
+            drawnGroupRecord.set("drawn_at", now);
             $app.save(drawnGroupRecord);
 
             const drawnParticipantIds = [];
@@ -162,6 +171,7 @@ if (env === "dev") {
                 partRecord.set("group_id", drawnGroupRecord.id);
                 partRecord.set("giver_id", userIds[i]);
                 partRecord.set("giver_name", userNames[i]);
+                partRecord.set("joined_at", now);
                 $app.save(partRecord);
                 drawnParticipantIds.push({ record: partRecord, userId: userIds[i], name: userNames[i] });
             }

--- a/db/pb_migrations/1782580733_collections_snapshot.js
+++ b/db/pb_migrations/1782580733_collections_snapshot.js
@@ -1,0 +1,1026 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const snapshot = [
+    {
+      "createRule": null,
+      "deleteRule": null,
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1582905952",
+          "max": 0,
+          "min": 0,
+          "name": "method",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_2279338944",
+      "indexes": [
+        "CREATE INDEX `idx_mfas_collectionRef_recordRef` ON `_mfas` (collectionRef,recordRef)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_mfas",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "createRule": null,
+      "deleteRule": null,
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cost": 8,
+          "help": "",
+          "hidden": true,
+          "id": "password901924565",
+          "max": 0,
+          "min": 0,
+          "name": "password",
+          "pattern": "",
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "password"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": true,
+          "id": "text3866985172",
+          "max": 0,
+          "min": 0,
+          "name": "sentTo",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_1638494021",
+      "indexes": [
+        "CREATE INDEX `idx_otps_collectionRef_recordRef` ON `_otps` (collectionRef, recordRef)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_otps",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "createRule": null,
+      "deleteRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text2462348188",
+          "max": 0,
+          "min": 0,
+          "name": "provider",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1044722854",
+          "max": 0,
+          "min": 0,
+          "name": "providerId",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_2281828961",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_externalAuths_record_provider` ON `_externalAuths` (collectionRef, recordRef, provider)",
+        "CREATE UNIQUE INDEX `idx_externalAuths_collection_provider` ON `_externalAuths` (collectionRef, provider, providerId)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_externalAuths",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "createRule": null,
+      "deleteRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text4228609354",
+          "max": 0,
+          "min": 0,
+          "name": "fingerprint",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_4275539003",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_authOrigins_unique_pairs` ON `_authOrigins` (collectionRef, recordRef, fingerprint)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_authOrigins",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "authAlert": {
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>We noticed a login to your {APP_NAME} account from a new location:</p>\n<p><em>{ALERT_INFO}</em></p>\n<p><strong>If this wasn't you, you should immediately change your {APP_NAME} account password to revoke access from all other locations.</strong></p>\n<p>If this was you, you may disregard this email.</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "Login from a new location"
+        },
+        "enabled": true
+      },
+      "authRule": "",
+      "authToken": {
+        "duration": 86400
+      },
+      "confirmEmailChangeTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to confirm your new email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-email-change/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Confirm new email</a>\n</p>\n<p><i>If you didn't ask to change your email address, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Confirm your {APP_NAME} new email address"
+      },
+      "createRule": null,
+      "deleteRule": null,
+      "emailChangeToken": {
+        "duration": 1800
+      },
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cost": 0,
+          "help": "",
+          "hidden": true,
+          "id": "password901924565",
+          "max": 0,
+          "min": 8,
+          "name": "password",
+          "pattern": "",
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "password"
+        },
+        {
+          "autogeneratePattern": "[a-zA-Z0-9]{50}",
+          "help": "",
+          "hidden": true,
+          "id": "text2504183744",
+          "max": 60,
+          "min": 30,
+          "name": "tokenKey",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "exceptDomains": null,
+          "help": "",
+          "hidden": false,
+          "id": "email3885137012",
+          "name": "email",
+          "onlyDomains": null,
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "email"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool1547992806",
+          "name": "emailVisibility",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool256245529",
+          "name": "verified",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "fileToken": {
+        "duration": 180
+      },
+      "id": "pbc_3142635823",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_tokenKey_pbc_3142635823` ON `_superusers` (`tokenKey`)",
+        "CREATE UNIQUE INDEX `idx_email_pbc_3142635823` ON `_superusers` (`email`) WHERE `email` != ''"
+      ],
+      "listRule": null,
+      "manageRule": null,
+      "mfa": {
+        "duration": 1800,
+        "enabled": false,
+        "rule": ""
+      },
+      "name": "_superusers",
+      "oauth2": {
+        "enabled": false,
+        "mappedFields": {
+          "avatarURL": "",
+          "id": "",
+          "name": "",
+          "username": ""
+        }
+      },
+      "otp": {
+        "duration": 180,
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>Your one-time password is: <strong>{OTP}</strong></p>\n<p><i>If you didn't ask for the one-time password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "OTP for {APP_NAME}"
+        },
+        "enabled": false,
+        "length": 8
+      },
+      "passwordAuth": {
+        "enabled": true,
+        "identityFields": [
+          "email"
+        ]
+      },
+      "passwordResetToken": {
+        "duration": 1800
+      },
+      "resetPasswordTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to reset your password.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-password-reset/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Reset password</a>\n</p>\n<p><i>If you didn't ask to reset your password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Reset your {APP_NAME} password"
+      },
+      "system": true,
+      "type": "auth",
+      "updateRule": null,
+      "verificationTemplate": {
+        "body": "<p>Hello,</p>\n<p>Thank you for joining us at {APP_NAME}.</p>\n<p>Click on the button below to verify your email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-verification/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Verify</a>\n</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Verify your {APP_NAME} email"
+      },
+      "verificationToken": {
+        "duration": 259200
+      },
+      "viewRule": null
+    },
+    {
+      "authAlert": {
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>We noticed a login to your {APP_NAME} account from a new location:</p>\n<p><em>{ALERT_INFO}</em></p>\n<p><strong>If this wasn't you, you should immediately change your {APP_NAME} account password to revoke access from all other locations.</strong></p>\n<p>If this was you, you may disregard this email.</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "Login from a new location"
+        },
+        "enabled": true
+      },
+      "authRule": "",
+      "authToken": {
+        "duration": 604800
+      },
+      "confirmEmailChangeTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to confirm your new email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-email-change/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Confirm new email</a>\n</p>\n<p><i>If you didn't ask to change your email address, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Confirm your {APP_NAME} new email address"
+      },
+      "createRule": "",
+      "deleteRule": "id = @request.auth.id",
+      "emailChangeToken": {
+        "duration": 1800
+      },
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cost": 0,
+          "help": "",
+          "hidden": true,
+          "id": "password901924565",
+          "max": 0,
+          "min": 8,
+          "name": "password",
+          "pattern": "",
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "password"
+        },
+        {
+          "autogeneratePattern": "[a-zA-Z0-9]{50}",
+          "help": "",
+          "hidden": true,
+          "id": "text2504183744",
+          "max": 60,
+          "min": 30,
+          "name": "tokenKey",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "exceptDomains": null,
+          "help": "",
+          "hidden": false,
+          "id": "email3885137012",
+          "name": "email",
+          "onlyDomains": null,
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "email"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool1547992806",
+          "name": "emailVisibility",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool256245529",
+          "name": "verified",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1579384326",
+          "max": 255,
+          "min": 0,
+          "name": "name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "file376926767",
+          "maxSelect": 1,
+          "maxSize": 0,
+          "mimeTypes": [
+            "image/jpeg",
+            "image/png",
+            "image/svg+xml",
+            "image/gif",
+            "image/webp"
+          ],
+          "name": "avatar",
+          "presentable": false,
+          "protected": false,
+          "required": false,
+          "system": false,
+          "thumbs": null,
+          "type": "file"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": false,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": false,
+          "type": "autodate"
+        }
+      ],
+      "fileToken": {
+        "duration": 180
+      },
+      "id": "_pb_users_auth_",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_tokenKey__pb_users_auth_` ON `users` (`tokenKey`)",
+        "CREATE UNIQUE INDEX `idx_email__pb_users_auth_` ON `users` (`email`) WHERE `email` != ''"
+      ],
+      "listRule": "id = @request.auth.id",
+      "manageRule": null,
+      "mfa": {
+        "duration": 1800,
+        "enabled": false,
+        "rule": ""
+      },
+      "name": "users",
+      "oauth2": {
+        "enabled": false,
+        "mappedFields": {
+          "avatarURL": "avatar",
+          "id": "",
+          "name": "name",
+          "username": ""
+        }
+      },
+      "otp": {
+        "duration": 180,
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>Your one-time password is: <strong>{OTP}</strong></p>\n<p><i>If you didn't ask for the one-time password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "OTP for {APP_NAME}"
+        },
+        "enabled": false,
+        "length": 8
+      },
+      "passwordAuth": {
+        "enabled": true,
+        "identityFields": [
+          "email"
+        ]
+      },
+      "passwordResetToken": {
+        "duration": 1800
+      },
+      "resetPasswordTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to reset your password.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-password-reset/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Reset password</a>\n</p>\n<p><i>If you didn't ask to reset your password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Reset your {APP_NAME} password"
+      },
+      "system": false,
+      "type": "auth",
+      "updateRule": "id = @request.auth.id",
+      "verificationTemplate": {
+        "body": "<p>Hello,</p>\n<p>Thank you for joining us at {APP_NAME}.</p>\n<p>Click on the button below to verify your email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-verification/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Verify</a>\n</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Verify your {APP_NAME} email"
+      },
+      "verificationToken": {
+        "duration": 259200
+      },
+      "viewRule": "id = @request.auth.id"
+    },
+    {
+      "createRule": "@request.auth.id != \"\"",
+      "deleteRule": "created_by = @request.auth.id",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1579384326",
+          "max": 0,
+          "min": 0,
+          "name": "name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1843675174",
+          "max": 0,
+          "min": 0,
+          "name": "description",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "_pb_users_auth_",
+          "help": "",
+          "hidden": false,
+          "id": "relation3725765462",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "created_by",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool1452349925",
+          "name": "has_been_drawn",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "bool"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "number3045082519",
+          "max": null,
+          "min": null,
+          "name": "participants_count",
+          "onlyInt": false,
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "number"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "date1438209652",
+          "max": "",
+          "min": "",
+          "name": "drawn_at",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "date"
+        }
+      ],
+      "id": "pbc_3346940990",
+      "indexes": [],
+      "listRule": "@request.auth.id != \"\"",
+      "name": "groups",
+      "system": false,
+      "type": "base",
+      "updateRule": "created_by = @request.auth.id",
+      "viewRule": "@request.auth.id != \"\""
+    },
+    {
+      "createRule": "@request.auth.id != \"\" && group_id.has_been_drawn = false",
+      "deleteRule": "@request.auth.id = giver_id || group_id.created_by = @request.auth.id",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "pbc_3346940990",
+          "help": "",
+          "hidden": false,
+          "id": "relation4266973511",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "group_id",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "_pb_users_auth_",
+          "help": "",
+          "hidden": false,
+          "id": "relation1975328041",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "giver_id",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "_pb_users_auth_",
+          "help": "",
+          "hidden": false,
+          "id": "relation3444829622",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "receiver_id",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text269413919",
+          "max": 255,
+          "min": 0,
+          "name": "giver_name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1533686328",
+          "max": 255,
+          "min": 0,
+          "name": "receiver_name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        }
+      ],
+      "id": "pbc_4144158273",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_uniqueParticipant_pbc_4144158273` ON `group_participants` (`group_id`, `giver_id`)"
+      ],
+      "listRule": "@request.auth.id = giver_id || @request.auth.id = receiver_id || group_id.created_by = @request.auth.id",
+      "name": "group_participants",
+      "system": false,
+      "type": "base",
+      "updateRule": "group_id.created_by = @request.auth.id",
+      "viewRule": "@request.auth.id = giver_id || @request.auth.id = receiver_id || group_id.created_by = @request.auth.id"
+    }
+  ];
+
+  return app.importCollections(snapshot, false);
+}, (app) => {
+  return null;
+})

--- a/db/pb_migrations/1782584073_collections_snapshot.js
+++ b/db/pb_migrations/1782584073_collections_snapshot.js
@@ -1,0 +1,1038 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const snapshot = [
+    {
+      "createRule": null,
+      "deleteRule": null,
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1582905952",
+          "max": 0,
+          "min": 0,
+          "name": "method",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_2279338944",
+      "indexes": [
+        "CREATE INDEX `idx_mfas_collectionRef_recordRef` ON `_mfas` (collectionRef,recordRef)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_mfas",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "createRule": null,
+      "deleteRule": null,
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cost": 8,
+          "help": "",
+          "hidden": true,
+          "id": "password901924565",
+          "max": 0,
+          "min": 0,
+          "name": "password",
+          "pattern": "",
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "password"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": true,
+          "id": "text3866985172",
+          "max": 0,
+          "min": 0,
+          "name": "sentTo",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_1638494021",
+      "indexes": [
+        "CREATE INDEX `idx_otps_collectionRef_recordRef` ON `_otps` (collectionRef, recordRef)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_otps",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "createRule": null,
+      "deleteRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text2462348188",
+          "max": 0,
+          "min": 0,
+          "name": "provider",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1044722854",
+          "max": 0,
+          "min": 0,
+          "name": "providerId",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_2281828961",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_externalAuths_record_provider` ON `_externalAuths` (collectionRef, recordRef, provider)",
+        "CREATE UNIQUE INDEX `idx_externalAuths_collection_provider` ON `_externalAuths` (collectionRef, provider, providerId)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_externalAuths",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "createRule": null,
+      "deleteRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text455797646",
+          "max": 0,
+          "min": 0,
+          "name": "collectionRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text127846527",
+          "max": 0,
+          "min": 0,
+          "name": "recordRef",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text4228609354",
+          "max": 0,
+          "min": 0,
+          "name": "fingerprint",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "id": "pbc_4275539003",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_authOrigins_unique_pairs` ON `_authOrigins` (collectionRef, recordRef, fingerprint)"
+      ],
+      "listRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId",
+      "name": "_authOrigins",
+      "system": true,
+      "type": "base",
+      "updateRule": null,
+      "viewRule": "@request.auth.id != '' && recordRef = @request.auth.id && collectionRef = @request.auth.collectionId"
+    },
+    {
+      "authAlert": {
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>We noticed a login to your {APP_NAME} account from a new location:</p>\n<p><em>{ALERT_INFO}</em></p>\n<p><strong>If this wasn't you, you should immediately change your {APP_NAME} account password to revoke access from all other locations.</strong></p>\n<p>If this was you, you may disregard this email.</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "Login from a new location"
+        },
+        "enabled": true
+      },
+      "authRule": "",
+      "authToken": {
+        "duration": 86400
+      },
+      "confirmEmailChangeTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to confirm your new email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-email-change/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Confirm new email</a>\n</p>\n<p><i>If you didn't ask to change your email address, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Confirm your {APP_NAME} new email address"
+      },
+      "createRule": null,
+      "deleteRule": null,
+      "emailChangeToken": {
+        "duration": 1800
+      },
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cost": 0,
+          "help": "",
+          "hidden": true,
+          "id": "password901924565",
+          "max": 0,
+          "min": 8,
+          "name": "password",
+          "pattern": "",
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "password"
+        },
+        {
+          "autogeneratePattern": "[a-zA-Z0-9]{50}",
+          "help": "",
+          "hidden": true,
+          "id": "text2504183744",
+          "max": 60,
+          "min": 30,
+          "name": "tokenKey",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "exceptDomains": null,
+          "help": "",
+          "hidden": false,
+          "id": "email3885137012",
+          "name": "email",
+          "onlyDomains": null,
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "email"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool1547992806",
+          "name": "emailVisibility",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool256245529",
+          "name": "verified",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": true,
+          "type": "autodate"
+        }
+      ],
+      "fileToken": {
+        "duration": 180
+      },
+      "id": "pbc_3142635823",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_tokenKey_pbc_3142635823` ON `_superusers` (`tokenKey`)",
+        "CREATE UNIQUE INDEX `idx_email_pbc_3142635823` ON `_superusers` (`email`) WHERE `email` != ''"
+      ],
+      "listRule": null,
+      "manageRule": null,
+      "mfa": {
+        "duration": 1800,
+        "enabled": false,
+        "rule": ""
+      },
+      "name": "_superusers",
+      "oauth2": {
+        "enabled": false,
+        "mappedFields": {
+          "avatarURL": "",
+          "id": "",
+          "name": "",
+          "username": ""
+        }
+      },
+      "otp": {
+        "duration": 180,
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>Your one-time password is: <strong>{OTP}</strong></p>\n<p><i>If you didn't ask for the one-time password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "OTP for {APP_NAME}"
+        },
+        "enabled": false,
+        "length": 8
+      },
+      "passwordAuth": {
+        "enabled": true,
+        "identityFields": [
+          "email"
+        ]
+      },
+      "passwordResetToken": {
+        "duration": 1800
+      },
+      "resetPasswordTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to reset your password.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-password-reset/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Reset password</a>\n</p>\n<p><i>If you didn't ask to reset your password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Reset your {APP_NAME} password"
+      },
+      "system": true,
+      "type": "auth",
+      "updateRule": null,
+      "verificationTemplate": {
+        "body": "<p>Hello,</p>\n<p>Thank you for joining us at {APP_NAME}.</p>\n<p>Click on the button below to verify your email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-verification/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Verify</a>\n</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Verify your {APP_NAME} email"
+      },
+      "verificationToken": {
+        "duration": 259200
+      },
+      "viewRule": null
+    },
+    {
+      "authAlert": {
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>We noticed a login to your {APP_NAME} account from a new location:</p>\n<p><em>{ALERT_INFO}</em></p>\n<p><strong>If this wasn't you, you should immediately change your {APP_NAME} account password to revoke access from all other locations.</strong></p>\n<p>If this was you, you may disregard this email.</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "Login from a new location"
+        },
+        "enabled": true
+      },
+      "authRule": "",
+      "authToken": {
+        "duration": 604800
+      },
+      "confirmEmailChangeTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to confirm your new email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-email-change/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Confirm new email</a>\n</p>\n<p><i>If you didn't ask to change your email address, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Confirm your {APP_NAME} new email address"
+      },
+      "createRule": "",
+      "deleteRule": "id = @request.auth.id",
+      "emailChangeToken": {
+        "duration": 1800
+      },
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cost": 0,
+          "help": "",
+          "hidden": true,
+          "id": "password901924565",
+          "max": 0,
+          "min": 8,
+          "name": "password",
+          "pattern": "",
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "password"
+        },
+        {
+          "autogeneratePattern": "[a-zA-Z0-9]{50}",
+          "help": "",
+          "hidden": true,
+          "id": "text2504183744",
+          "max": 60,
+          "min": 30,
+          "name": "tokenKey",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "exceptDomains": null,
+          "help": "",
+          "hidden": false,
+          "id": "email3885137012",
+          "name": "email",
+          "onlyDomains": null,
+          "presentable": false,
+          "required": true,
+          "system": true,
+          "type": "email"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool1547992806",
+          "name": "emailVisibility",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool256245529",
+          "name": "verified",
+          "presentable": false,
+          "required": false,
+          "system": true,
+          "type": "bool"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1579384326",
+          "max": 255,
+          "min": 0,
+          "name": "name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "file376926767",
+          "maxSelect": 1,
+          "maxSize": 0,
+          "mimeTypes": [
+            "image/jpeg",
+            "image/png",
+            "image/svg+xml",
+            "image/gif",
+            "image/webp"
+          ],
+          "name": "avatar",
+          "presentable": false,
+          "protected": false,
+          "required": false,
+          "system": false,
+          "thumbs": null,
+          "type": "file"
+        },
+        {
+          "hidden": false,
+          "id": "autodate2990389176",
+          "name": "created",
+          "onCreate": true,
+          "onUpdate": false,
+          "presentable": false,
+          "system": false,
+          "type": "autodate"
+        },
+        {
+          "hidden": false,
+          "id": "autodate3332085495",
+          "name": "updated",
+          "onCreate": true,
+          "onUpdate": true,
+          "presentable": false,
+          "system": false,
+          "type": "autodate"
+        }
+      ],
+      "fileToken": {
+        "duration": 180
+      },
+      "id": "_pb_users_auth_",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_tokenKey__pb_users_auth_` ON `users` (`tokenKey`)",
+        "CREATE UNIQUE INDEX `idx_email__pb_users_auth_` ON `users` (`email`) WHERE `email` != ''"
+      ],
+      "listRule": "id = @request.auth.id",
+      "manageRule": null,
+      "mfa": {
+        "duration": 1800,
+        "enabled": false,
+        "rule": ""
+      },
+      "name": "users",
+      "oauth2": {
+        "enabled": false,
+        "mappedFields": {
+          "avatarURL": "avatar",
+          "id": "",
+          "name": "name",
+          "username": ""
+        }
+      },
+      "otp": {
+        "duration": 180,
+        "emailTemplate": {
+          "body": "<p>Hello,</p>\n<p>Your one-time password is: <strong>{OTP}</strong></p>\n<p><i>If you didn't ask for the one-time password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+          "subject": "OTP for {APP_NAME}"
+        },
+        "enabled": false,
+        "length": 8
+      },
+      "passwordAuth": {
+        "enabled": true,
+        "identityFields": [
+          "email"
+        ]
+      },
+      "passwordResetToken": {
+        "duration": 1800
+      },
+      "resetPasswordTemplate": {
+        "body": "<p>Hello,</p>\n<p>Click on the button below to reset your password.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-password-reset/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Reset password</a>\n</p>\n<p><i>If you didn't ask to reset your password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Reset your {APP_NAME} password"
+      },
+      "system": false,
+      "type": "auth",
+      "updateRule": "id = @request.auth.id",
+      "verificationTemplate": {
+        "body": "<p>Hello,</p>\n<p>Thank you for joining us at {APP_NAME}.</p>\n<p>Click on the button below to verify your email address.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/_/#/auth/confirm-verification/{TOKEN}\" target=\"_blank\" rel=\"noopener\">Verify</a>\n</p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",
+        "subject": "Verify your {APP_NAME} email"
+      },
+      "verificationToken": {
+        "duration": 259200
+      },
+      "viewRule": "id = @request.auth.id"
+    },
+    {
+      "createRule": "@request.auth.id != \"\"",
+      "deleteRule": "created_by = @request.auth.id",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1579384326",
+          "max": 0,
+          "min": 0,
+          "name": "name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1843675174",
+          "max": 0,
+          "min": 0,
+          "name": "description",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "_pb_users_auth_",
+          "help": "",
+          "hidden": false,
+          "id": "relation3725765462",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "created_by",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "bool1452349925",
+          "name": "has_been_drawn",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "bool"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "number3045082519",
+          "max": null,
+          "min": null,
+          "name": "participants_count",
+          "onlyInt": false,
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "number"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "date1438209652",
+          "max": "",
+          "min": "",
+          "name": "drawn_at",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "date"
+        }
+      ],
+      "id": "pbc_3346940990",
+      "indexes": [],
+      "listRule": "@request.auth.id != \"\"",
+      "name": "groups",
+      "system": false,
+      "type": "base",
+      "updateRule": "created_by = @request.auth.id",
+      "viewRule": "@request.auth.id != \"\""
+    },
+    {
+      "createRule": "@request.auth.id != \"\" && group_id.has_been_drawn = false",
+      "deleteRule": "@request.auth.id = giver_id || group_id.created_by = @request.auth.id",
+      "fields": [
+        {
+          "autogeneratePattern": "[a-z0-9]{15}",
+          "help": "",
+          "hidden": false,
+          "id": "text3208210256",
+          "max": 15,
+          "min": 15,
+          "name": "id",
+          "pattern": "^[a-z0-9]+$",
+          "presentable": false,
+          "primaryKey": true,
+          "required": true,
+          "system": true,
+          "type": "text"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "pbc_3346940990",
+          "help": "",
+          "hidden": false,
+          "id": "relation4266973511",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "group_id",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "_pb_users_auth_",
+          "help": "",
+          "hidden": false,
+          "id": "relation1975328041",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "giver_id",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "cascadeDelete": false,
+          "collectionId": "_pb_users_auth_",
+          "help": "",
+          "hidden": false,
+          "id": "relation3444829622",
+          "maxSelect": 0,
+          "minSelect": 0,
+          "name": "receiver_id",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "relation"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text269413919",
+          "max": 255,
+          "min": 0,
+          "name": "giver_name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "autogeneratePattern": "",
+          "help": "",
+          "hidden": false,
+          "id": "text1533686328",
+          "max": 255,
+          "min": 0,
+          "name": "receiver_name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": false,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "help": "",
+          "hidden": false,
+          "id": "date2745685176",
+          "max": "",
+          "min": "",
+          "name": "joined_at",
+          "presentable": false,
+          "required": false,
+          "system": false,
+          "type": "date"
+        }
+      ],
+      "id": "pbc_4144158273",
+      "indexes": [
+        "CREATE UNIQUE INDEX `idx_uniqueParticipant_pbc_4144158273` ON `group_participants` (`group_id`, `giver_id`)"
+      ],
+      "listRule": "@request.auth.id = giver_id || @request.auth.id = receiver_id || group_id.created_by = @request.auth.id",
+      "name": "group_participants",
+      "system": false,
+      "type": "base",
+      "updateRule": "group_id.created_by = @request.auth.id",
+      "viewRule": "@request.auth.id = giver_id || @request.auth.id = receiver_id || group_id.created_by = @request.auth.id"
+    }
+  ];
+
+  return app.importCollections(snapshot, false);
+}, (app) => {
+  return null;
+})

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -115,11 +115,17 @@ O "Com Quem Será" é um sistema de amigo secreto que resolve o problema de orga
 
 ```mermaid
 flowchart LR
-    subgraph Navegador
-        A[Angular SPA]
+    subgraph "Build Time (Docker)"
+        NGINX_FS["📁 Nginx filesystem<br>(/usr/share/nginx/html)"]
+        BUILD["🛠 ng build<br>(dist/frontend/browser)"]
+        BUILD -->|"COPY"| NGINX_FS
     end
     
-    subgraph Docker Host
+    subgraph "Runtime (Navegador)"
+        A["Angular SPA<br>(executando no browser)"]
+    end
+    
+    subgraph "Docker Host (Runtime)"
         subgraph "Container: Nginx (:80)"
             N[Proxy Reverso]
         end
@@ -127,13 +133,13 @@ flowchart LR
         subgraph "Container: Pocketbase (:8090)"
             P[API + Auth + SQLite]
         end
-        
-        N -->|"/api/*"| P
-        N -->|"/* (SPA)"| A
     end
     
-    A -->|"HTTP via Nginx"| N
-    P -->|"Respostas JSON"| N
+    A -->|"HTTP GET / → index.html"| N
+    A -->|"HTTP /api/*"| N
+    N -->|"proxy_pass"| P
+    P -->|"JSON"| N
+    N -->|"JSON"| A
 ```
 
 ### 8.6. Diretrizes Técnicas Obrigatórias
@@ -330,7 +336,7 @@ Cada card deve conter as seguintes informações e ações:
 | 3 | Usuário clica em "Criar grupo". |
 | 4 | Sistema valida o nome do grupo. |
 | 5 | Sistema cria o registro na tabela `group` com: <br> - `name` = valor do campo <br> - `description` = null (ou vazio) <br> - `created_by` = `currentUser.id` <br> - `has_been_drawn` = false <br> - `participants_count` = 0 (inicial) |
-| 6 | **Se o checkbox "Participar do grupo" estiver marcado:** <br> Sistema cria um registro em `group_participant` com: <br> - `group_id` = ID do grupo recém-criado <br> - `giver_id` = null <br> - `receiver_id` = null <br> - `joined_at` = data atual <br> E incrementa `participants_count` do grupo para 1. |
+| 6 | **Se o checkbox "Participar do grupo" estiver marcado:** <br> Sistema cria um registro em `group_participant` com: <br> - `group_id` = ID do grupo recém-criado <br> - `giver_id` = `currentUser.id` (usuário que entrou é o próprio giver) <br> - `giver_name` = nome do `currentUser` <br> - `receiver_id` = null <br> - `receiver_name` = null <br> - `joined_at` = data atual <br> E incrementa `participants_count` do grupo para 1. |
 | 7 | **Se o checkbox NÃO estiver marcado:** <br> O grupo é criado sem participantes. O organizador (criador) não participa do sorteio. |
 | 8 | Sistema redireciona o usuário para a tela de dashboard do grupo (`/group/:groupId`). |
 | 9 | Opcionalmente, exibir mensagem de sucesso: "Grupo [nome] criado com sucesso!" |
@@ -402,7 +408,7 @@ flowchart TD
 
 ---
 
-##### 9.4.3. Fluxo do Link de Convite (`/join`)
+##### 9.5.3. Fluxo do Link de Convite (`/join`)
 
 ```mermaid
 flowchart TD
@@ -411,12 +417,13 @@ flowchart TD
     C --> D[Usuário faz login]
     D --> E[Redireciona para /join?code=xxx]
     E --> B
-    B -->|Sim| F[Chama GET /api/join?code=xxx<br>via PocketBase hook]
-    F --> G[Valida grupo, cria participante,<br>incrementa participants_count]
-    G --> H[Redireciona para /group/:groupId]
-    H --> I{É created_by ou participante?}
-    I -->|created_by| J[Visão do Criador]
-    I -->|Participante| K[Visão do Participante]
+    B -->|Sim| F[Busca grupo via groupService.getByInviteCode]
+    F --> G{O usuário é o<br>created_by do grupo?}
+    G -->|Sim| H[Redireciona para /group/:groupId]
+    G -->|Não| I[Cria participante via<br>participantService.joinGroup]
+    I --> J[Redireciona para /group/:groupId]
+    H --> K[Visão do Criador ou Participante]
+    J --> K
 ```
 
 ---
@@ -442,14 +449,14 @@ flowchart TD
 
 | Ação | Condição | Comportamento |
 | :--- | :--- | :--- |
-| **"Tornar-se membro"** | Criador NÃO está na lista de participantes (`group_participant` não existe para este user no grupo) | Adiciona o criador como participante. Cria registro `group_participant` com `giver_id` = null, `receiver_id` = null. Incrementa `participants_count`. Exibe mensagem de sucesso. |
-| **"Deixar de ser membro"** | Criador ESTÁ na lista de participantes E grupo tem mais de 1 participante (não é o único) | Remove o criador da lista de participantes. Deleta registro `group_participant`. Decrementa `participants_count`. Exibe mensagem de sucesso. |
+| **"Tornar-se membro"** | Criador NÃO está na lista de participantes (`group_participant` não existe para este user no grupo) | Botão habilitado. Exibe modal de confirmação: "Deseja entrar como participante do grupo [nome]?" Após confirmação, adiciona o criador como participante. Cria registro `group_participant` com `giver_id` = null, `receiver_id` = null. Incrementa `participants_count`. Exibe mensagem de sucesso. |
+| **"Deixar de ser membro"** | Criador ESTÁ na lista de participantes E grupo tem mais de 1 participante (não é o único) | Botão habilitado. Exibe modal de confirmação: "Tem certeza que deseja deixar de ser membro do grupo [nome]?" Após confirmação, remove o criador da lista de participantes. Deleta registro `group_participant`. Decrementa `participants_count`. Exibe mensagem de sucesso. |
 | **"Deixar de ser membro" (bloqueado)** | Criador é o ÚNICO participante do grupo | Botão desabilitado com tooltip: "Você é o único participante. Adicione mais pessoas antes de sair." |
 | **"Copiar link de convite"** | Sorteio NÃO realizado | Copia o URL de convite para a área de transferência. Exibir feedback "Link copiado!". Oculta a seção de convite após o sorteio. |
-| **"Realizar sorteio"** | Mínimo 3 participantes E sorteio NÃO realizado | Executa o algoritmo de sorteio (via API custom). Preenche `giver_id` e `receiver_id` para todos os participantes. Marca `has_been_drawn = true`. Redireciona para `/group/:groupId/admin` (ou exibe resultados na mesma tela). |
+| **"Realizar sorteio"** | Mínimo 3 participantes E sorteio NÃO realizado | Exibe modal de confirmação: "Tem certeza que deseja realizar o sorteio? Esta ação não pode ser desfeita." Após confirmação, executa o algoritmo de sorteio (via API custom). Preenche `giver_id` e `receiver_id` para todos os participantes. Marca `has_been_drawn = true`. Redireciona para `/group/:groupId/admin` (ou exibe resultados na mesma tela). |
 | **"Realizar sorteio" (bloqueado)** | Menos de 3 participantes | Botão desabilitado com tooltip: "É necessário no mínimo 3 participantes para realizar o sorteio." |
 | **"Realizar sorteio" (bloqueado)** | Sorteio já realizado | Botão oculto ou desabilitado com tooltip: "O sorteio deste grupo já foi realizado." |
-| **"Excluir grupo"** | Sorteio NÃO realizado | Abre modal de confirmação: "Tem certeza que deseja excluir o grupo [nome]? Esta ação não pode ser desfeita." Após confirmação, deleta o grupo e todos os `group_participant` associados. Redireciona para `/my-groups`. |
+| **"Excluir grupo"** | Sorteio NÃO realizado | Exibe modal de confirmação: "Tem certeza que deseja excluir o grupo [nome]? Esta ação não pode ser desfeita." Após confirmação, deleta o grupo e todos os `group_participant` associados. Redireciona para `/my-groups`. |
 | **"Excluir grupo" (bloqueado)** | Sorteio já realizado | Botão oculto ou desabilitado com tooltip: "Grupos com sorteio realizado não podem ser excluídos." |
 
 ##### 9.5.1.3. Ações do Organizador (Pós-sorteio)
@@ -504,14 +511,14 @@ flowchart TD
 | Situação | Exibição e Ações |
 | :--- | :--- |
 | Sorteio NÃO realizado (`has_been_drawn = false`) | Badge "Aguardando sorteio". Botão "Sair do grupo" disponível. Área de revelação do amigo secreto oculta ou exibe "Aguardando sorteio...". |
-| Sorteio realizado (`has_been_drawn = true`) | Badge "Sorteio realizado!". Área de revelação do amigo secreto **exibe o nome da pessoa que o participante deve presentear**. Botão "Sair do grupo" **NÃO é exibido** (participante não pode sair após sorteio). |
+| Sorteio realizado (`has_been_drawn = true`) | Badge "Sorteio realizado!". Área de revelação do amigo secreto **exibe o nome da pessoa que o participante deve presentear**. Botão "Deixar de ser membro" **NÃO é exibido** (participante não pode sair após sorteio). |
 
 ##### 9.5.2.2. Ações do Participante
 
 | Ação | Condição | Comportamento |
 | :--- | :--- | :--- |
-| **"Sair do grupo"** | Sorteio NÃO realizado | Abre modal de confirmação: "Tem certeza que deseja sair do grupo [nome]?" Após confirmação, deleta o registro `group_participant` do usuário. Decrementa `participants_count`. Redireciona para `/my-groups`. |
-| **"Sair do grupo"** | Sorteio já realizado | **Botão NÃO é exibido** (ou oculto). Participante não pode sair após o sorteio ser realizado. |
+| **"Deixar de ser membro"** | Sorteio NÃO realizado | Botão habilitado. Exibe modal de confirmação: "Tem certeza que deseja sair do grupo [nome]?" Após confirmação, deleta o registro `group_participant` do usuário. Decrementa `participants_count`. Redireciona para `/my-groups`. |
+| **"Deixar de ser membro"** | Sorteio já realizado | **Botão NÃO é exibido** (ou oculto). Participante não pode sair após o sorteio ser realizado. |
 | **"Copiar link de convite"** | Apenas se o participante quiser convidar outros (opcional) | Copia o link de convite. Se sorteio já realizado, exibir aviso: "O sorteio já foi realizado. Novos participantes não podem entrar." |
 
 ##### 9.5.2.3. Revelação do Amigo Secreto (Área de Destaque)

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -30,7 +30,7 @@
 | Termo PRD (PT-BR) | Entidade Técnica (EN) | Atributos Principais |
 | :--- | :--- | :--- |
 | Usuário | `user` (coleção nativa Pocketbase) | `id`, `name`, `email`, `verified`, `emailVisibility` |
-| Grupo | `group` | `id`, `name`, `description`, `created_by` (FK user.id), `created_at`, `has_been_drawn` |
+| Grupo | `group` | `id`, `name`, `description`, `created_by` (FK user.id), `created_at`, `has_been_drawn`, `drawn_at`, `participants_count` |
 | Participante | `group_participant` | `id`, `group_id` (FK), `giver_id` (FK user.id, NULL antes sorteio), `receiver_id` (FK user.id, NULL antes sorteio), `joined_at` |
 | Sorteio (implícito) | Atualização em massa dos `giver_id` e `receiver_id` na tabela `group_participant` | - |
 
@@ -45,6 +45,7 @@ erDiagram
         string created_by "default: @request.auth.id"
         datetime created_at "default: NOW()"
         boolean has_been_drawn "default: false"
+        datetime drawn_at "NULL"
         int participants_count "default: 0"
     }
     
@@ -63,15 +64,17 @@ erDiagram
         string id PK
         string giver_id FK "NULL"
         string receiver_id FK "NULL"
+        string giver_name "NULL"
+        string receiver_name "NULL"
         string group_id FK "NN"
         datetime joined_at "default: NOW()"
     }
     
 
     user ||--o{ group : created_by
-    group ||--o{ group_paticipant : group_id
-    user ||--o{ group_paticipant : giver_id
-    user ||--o{ group_paticipant : receiver_id
+    group ||--o{ group_participant : group_id
+    user ||--o{ group_participant : giver_id
+    user ||--o{ group_participant : receiver_id
 ```
 
 ## 📑 4. Contratos Globais (Interfaces & Types)
@@ -112,6 +115,7 @@ export interface Group {
   created_by: string;   // user.id
   created_at: string;   // ISO date
   has_been_drawn: boolean;
+  drawn_at?: string;    // ISO date
   participants_count: number;
   expand?: {
     created_by?: User;
@@ -119,13 +123,15 @@ export interface Group {
   };
 }
 
-export type CreateGroupDTO = Omit<Group, 'id' | 'created_at' | 'has_been_drawn'>;
+export type CreateGroupDTO = Omit<Group, 'id' | 'created_at' | 'has_been_drawn' | 'drawn_at'>;
 
 // src/app/core/models/group-participant.model.ts
 export interface GroupParticipant {
   id: string;
   giver_id: string | null;      // quem presenteia (preenchido após sorteio)
+  giver_name: string;           // denormalized name do giver
   receiver_id: string | null;   // quem recebe (preenchido após sorteio)
+  receiver_name: string | null; // denormalized name do receiver
   group_id: string;
   joined_at: string;            // ISO date
   expand?: {
@@ -135,7 +141,7 @@ export interface GroupParticipant {
   };
 }
 
-export type JoinGroupDTO = Omit<GroupParticipant, 'id' | 'joined_at' | 'giver_id' | 'receiver_id'>;
+export type JoinGroupDTO = Omit<GroupParticipant, 'id' | 'joined_at'>;
 
 // DTO para atualização de perfil
 export interface UpdateProfileDTO {
@@ -195,7 +201,6 @@ projeto/
 | `/create` | `features/create-group/create-group.page.ts` | `authGuard` |
 | `/join` | `features/join-group/join-group.page.ts` (query param `?code=xxx`) | `authGuard` |
 | `/group/:groupId` | `features/group-dashboard/group-dashboard.page.ts` | `authGuard`, `groupExistsGuard` |
-| `/group/:groupId/reveal` | `features/reveal/reveal.page.ts` | `authGuard`, `groupExistsGuard`, `drawAvailableGuard` |
 | `/group/:groupId/admin` | `features/admin/admin-dashboard.page.ts` | `authGuard`, `groupExistsGuard`, `isOrganizerGuard` |
 | `/profile` | `features/profile/profile.page.ts` (placeholder) | `authGuard` |
 
@@ -274,12 +279,11 @@ flowchart LR
     end
     
     subgraph Volumes
-        V1["/s7/ → /s8/"]
-        V2["/s9/ → /s10/"]
-        V3["/s11/ → /s12/"]
-        V4["/s13/ → /s14/"]
-        V5["/s15/ → /s16/"]
-        V6["/s17/ → /s18/"]
+        V1["./apps/web/dist/frontend/browser"]
+        V2["./server/logs"]
+        V3["pocketbase_data<br>(named volume)"]
+        V4["./db/pb_hooks"]
+        V5["./db/pb_migrations"]
     end
     
     N --> V1
@@ -287,7 +291,6 @@ flowchart LR
     PB --> V3
     PB --> V4
     PB --> V5
-    PB --> V6
     
     User((Usuário)) -->|HTTP :80| N
     N -->|"/api/*"| PB
@@ -630,14 +633,6 @@ O projeto utiliza um arquivo `.env` para gerenciar configurações e segredos. U
 ### ⚠️ Importante
 - O arquivo `.env` **não deve ser versionado** (já incluído no `.gitignore`).
 - Em produção, certifique-se de usar senhas fortes.
-
-## Biblioteca de Componentes Escolhida
-
-A equipe optou por utilizar o DaisyUI.
-
-A decisão foi baseada na velocidade de desenvolvimento, já que a biblioteca fornece componentes prontos integrados ao Tailwind, permitindo a criação de interfaces modernas com menos esforço e configuração.
-
----
 
 ## 📝 9. Convenção de Commits
 


### PR DESCRIPTION
**Origem:** `SamuelPatrickMeneses/feat/10/draw`
**Destino:** `develop`
**Issues relacionadas:** Closes #10, Closes #11

---

## 📋 Descrição

Implementa o sorteio (Fisher-Yates) com modal de confirmação reutilizável, joined_at nos participantes, e área de revelação segura com toggle ocultar/mostrar para o amigo secreto.

## ✨ O que foi feito

- Implementa algoritmo Fisher-Yates com garantia de que ninguém tira a si mesmo (derangement)
- Cria componente `confirm-modal` reutilizável substituindo `window.confirm`
- Adiciona confirmação modal para: realizar sorteio, entrar/sair do grupo, remover participante, sair e excluir grupo
- Exibe `joined_at` na lista de participantes ordenada dos mais recentes
- Adiciona toggle de revelação segura (oculto por padrão, botão REVELAR/OCULTAR)
- Exibe mensagem "NÃO CONTE PARA NINGUÉM!" apenas quando revelado
- Atualiza PRD e SDD para alinhar documentação (diagramas, glossário, DTOs)
- Adiciona testes unitários e de integração para todas as mudanças

## 🔧 Arquivos modificados

```
.
├── apps
│   └── web
│       └── src
│           └── app
│               ├── core
│               │   ├── models
│               │   │   └── group.model.ts
│               │   └── services
│               │       ├── draw.service.spec.ts
│               │       ├── draw.service.ts
│               │       ├── participant.service.spec.ts
│               │       └── participant.service.ts
│               ├── features
│               │   ├── admin
│               │   │   └── admin-dashboard.page.spec.ts
│               │   ├── create-group
│               │   │   └── create-group.page.spec.ts
│               │   ├── group-dashboard
│               │   │   ├── group-dashboard.page.html
│               │   │   ├── group-dashboard.page.spec.ts
│               │   │   └── group-dashboard.page.ts
│               │   └── my-groups
│               │       └── my-groups.page.spec.ts
│               └── shared
│                   └── components
│                       └── confirm-modal
│                           └── confirm-modal.component.ts
├── db
│   ├── pb_hooks
│   │   └── seed.pb.js
│   └── pb_migrations
│       ├── 1782580733_collections_snapshot.js
│       └── 1782584073_collections_snapshot.js
└── docs
    ├── prd.md
    └── sdd.md
```

## 🧪 Como testar

```bash
npm run docker:test
```