### PR TITLE
chore: restructure docker-compose for production and add PB_DASHBOARD_ENABLED

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
 
-  build:
+  angular-dev:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
@@ -12,12 +12,31 @@ services:
       - ./apps/web/dist/frontend/browser:/app/apps/web/dist/frontend/browser
     environment:
       - APP_ENV=${APP_ENV:-prod}
+      - PB_DASHBOARD_ENABLED=${PB_DASHBOARD_ENABLED:-true}
     healthcheck:
       test: ["CMD-SHELL", "test -f /app/apps/web/dist/frontend/browser/index.html"]
       interval: 5s
       timeout: 5s
       retries: 12
       start_period: 30s
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+      target: production
+    container_name: web
+    profiles:
+      - prod
+    ports:
+      - "80:80"
+    depends_on:
+      pocketbase:
+        condition: service_started
+    environment:
+      - PB_DASHBOARD_ENABLED=false
+    networks:
+      - amigo-secreto-network
 
   test:
     build:
@@ -75,19 +94,18 @@ services:
     networks:
       - amigo-secreto-network
 
-  nginx:
+  nginx-dev:
     image: nginx:alpine
-    container_name: nginx
+    container_name: nginx-dev
     restart: unless-stopped
     profiles:
       - dev
-      - prod
     ports:
       - "80:80"
     environment:
       - APP_ENV=${APP_ENV:-prod}
-      - NGINX_ENVSUBST_FILTER=APP_ENV
-      - DOCKER_BUILD_CONDITION=${DOCKER_BUILD_CONDITION:-service_completed_successfully}
+      - PB_DASHBOARD_ENABLED=true
+      - NGINX_ENVSUBST_FILTER=PB_DASHBOARD_ENABLED
     env_file:
       - .env
     volumes:
@@ -97,8 +115,8 @@ services:
     depends_on:
       pocketbase:
         condition: service_started
-      build:
-        condition: $DOCKER_BUILD_CONDITION
+      angular-dev:
+        condition: service_started
     networks:
       - amigo-secreto-network
 

--- a/server/default.conf.template
+++ b/server/default.conf.template
@@ -26,11 +26,10 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Proxy para admin UI do Pocketbase (apenas em desenvolvimento)
+    # Proxy para admin UI do Pocketbase (controlado por PB_DASHBOARD_ENABLED)
     location ^~ /_/ {
-        # Bloqueio se não for ambiente de desenvolvimento
-        set $env_mode "${APP_ENV}";
-        if ($env_mode != "dev") {
+        set $pb_dashboard "${PB_DASHBOARD_ENABLED}";
+        if ($pb_dashboard != "true") {
             return 403;
         }
 


### PR DESCRIPTION
**Origem:** fix/build-permissions
**Destino:** main

---

## 📋 Descrição

Reestrutura o docker-compose.yml para separar perfis dev e prod, adiciona serviço `web` autossuficiente para produção (sem bind volumes), e substitui `APP_ENV` por `PB_DASHBOARD_ENABLED` para controle do dashboard do PocketBase.

## ✨ O que foi feito

- Adiciona serviço `web` com target `production` (nginx + Angular buildado na imagem, sem bind mounts)
- Renomeia `build` → `angular-dev` (profile dev, livereload)
- Restringe `nginx-dev` ao profile dev (remove prod)
- Substitui `APP_ENV` por `PB_DASHBOARD_ENABLED` no bloqueio do dashboard `/_/`
- Define `PB_DASHBOARD_ENABLED=false` no `web` (produção bloqueado por padrão)
- Define `PB_DASHBOARD_ENABLED=true` no `nginx-dev` (dev liberado)

## 🔧 Arquivos modificados

```
 docker-compose.yml           | 34 ++++++++++++++++++++++++++--------
 server/default.conf.template |  7 +++----
```

## 🧪 Como testar

```bash
npm run docker:test
```
