### PR TITLE
fix: Wait for redirect navigation to settle after RouterTestingHarness.navigateByUrl

### DIFF
--- a/apps/web/src/app/navigation.spec.ts
+++ b/apps/web/src/app/navigation.spec.ts
@@ -213,6 +213,7 @@ describe('AppNavigation (integração)', () => {
     const harness = await RouterTestingHarness.create();
     await harness.navigateByUrl('/join?code=test123');
     const router = TestBed.inject(Router);
+    await new Promise(resolve => setTimeout(resolve));
     expect(router.url).toContain('/login');
     expect(router.url).toContain(encodeURIComponent('/join?code=test123'));
   });


### PR DESCRIPTION
**Origem:** `fix/join-redirect-test`
**Destino:** `main`

---

## 📋 Descrição

Corrige teste de integração `AppNavigation (integração) > "/join?code=xxx" without auth redirects to /login with returnUrl` que falhava porque o `RouterTestingHarness.navigateByUrl` resolvia antes do redirect disparado pelo `ngOnInit` do `JoinComponent` completar.

## ✨ O que foi feito

- Adiciona `await new Promise(resolve => setTimeout(resolve))` após `navigateByUrl` para ceder ao event loop e permitir que a navegação do `router.navigate` se complete antes de verificar a URL

## 🔧 Arquivos modificados

```
 apps/web/src/app/navigation.spec.ts | 1 +
 1 file changed, 1 insertion(+)
```

## 🧪 Como testar

```bash
npm run docker:test
```