### PR TITLE
fix: Remove duplicate web service definition in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,24 +36,6 @@ services:
       - POCKETBASE_HOST=pocketbase
       - PB_DASHBOARD_ENABLED=${PB_DASHBOARD_ENABLED:-false}
 
-  web:
-    build:
-      context: .
-      dockerfile: apps/web/Dockerfile
-      target: production
-    container_name: web
-    profiles:
-      - prod
-    ports:
-      - "80"
-    depends_on:
-      pocketbase:
-        condition: service_started
-    environment:
-      - PB_DASHBOARD_ENABLED=false
-    networks:
-      - amigo-secreto-network
-
   test:
     build:
       context: .


### PR DESCRIPTION
**Origem:** `fix/duplicate-web-service`
**Destino:** `develop`

---

## 📋 Descrição

Corrige erro de parsing do Docker Compose causado por chave YAML duplicada. Durante um merge anterior, duas definições do service `web` foram mantidas no `docker-compose.yml`, impedindo a execução de `npm run docker:test`.

## ✨ O que foi feito

- Remove a segunda definição duplicada do service `web` (linhas 39-56)
- O bloco mantido é o primeiro (linhas 25-37), que contém as env vars `POCKETBASE_HOST` e `PB_DASHBOARD_ENABLED` com fallback

## 🔧 Arquivos modificados

```
docker-compose.yml
```

## 🧪 Como testar

```bash
npm run docker:test
```