### PR TITLE
chore: prefix MCP env vars with COM_QUEM_SERAA_ in opencode.json

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -6,7 +6,7 @@
       "url": "https://stitch.googleapis.com/mcp",
       "enabled": true,
       "headers": {
-        "X-Goog-Api-Key": "{env:STITCH_API_KEY}"
+        "X-Goog-Api-Key": "{env:COM_QUEM_SERAA_STITCH_API_KEY}"
       }
     },
     "github": {
@@ -24,7 +24,7 @@
       "type": "local",
       "enabled": true,
       "environment": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "{env:GITHUB_PERSONAL_ACCESS_TOKEN}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "{env:COM_QUEM_SERAA_GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     }
   },
@@ -38,7 +38,7 @@
       "template": "You must follow the instructions in @.agent/skills/angular-workflow/SKILL.md.\nExecute the audit checklist and return a structured report.",
       "description": "🧱 Audita a arquitetura Angular: Feature-Driven (core/shared/features), standalone-only, Tailwind-only, rotas",
       "agent": "build"
-    },
+    }
   }
 }
 


### PR DESCRIPTION
**Origem:** `chore/prefix-env-vars`
**Destino:** `develop`
**Issues relacionadas:** —

---

## Descrição

Renomeia as referências das variáveis de ambiente no `opencode.json` com o prefixo `COM_QUEM_SERAA_` alinhado ao nome do projeto e corrige um trailing comma que tornava o JSON inválido.

## O que foi feito

- Renomeia `{env:STITCH_API_KEY}` para `{env:COM_QUEM_SERAA_STITCH_API_KEY}` no header do MCP do Stitch
- Renomeia `{env:GITHUB_PERSONAL_ACCESS_TOKEN}` para `{env:COM_QUEM_SERAA_GITHUB_PERSONAL_ACCESS_TOKEN}` na configuração do MCP do GitHub
- Corrige trailing comma após a command `angular-workflow`

## Arquivos modificados

```
opencode.json
```

## Como testar

```bash
node -e "JSON.parse(require('fs').readFileSync('opencode.json','utf8'))" && echo OK
```

A renomeação das variáveis em `~/.config/opencode/.env` (local) deve acompanhar o novo prefixo.